### PR TITLE
Use feature-test macro for std:start_lifetime_as

### DIFF
--- a/include/bye_trie/bye_trie.h
+++ b/include/bye_trie/bye_trie.h
@@ -848,7 +848,7 @@ D* as_ptr(S& ptr) noexcept
     requires(sizeof(D) == sizeof(S))
 {
     return
-#if __cplusplus >= 202300L
+#ifdef __cpp_lib_start_lifetime_as
             std::start_lifetime_as<D>(&ptr)
 #elif defined(bye_trie_STRICT_ALIASING)
             new (ptr) T(std::bit_cast<D>(ptr));
@@ -863,7 +863,7 @@ D* as_ptr(S& ptr) noexcept
     requires(sizeof(D) != sizeof(S))
 {
     return
-#if __cplusplus >= 202300L
+#ifdef __cpp_lib_start_lifetime_as
             std::start_lifetime_as<D>(&ptr)
 #else
             reinterpret_cast<D*>(&ptr) // UB! OK if strict aliasing is off


### PR DESCRIPTION
Currently, the explicit lifetime management is not implemented by Clang. So, `std::start_lifetime_as` is not available. It causes a compilation error if I try to build the project with Clang and -std=c++23.

These changes suggest using the feature-test macro instead of relying on the version of the C++ standard. This way, `std::start_lifetime_as` will be used only if a compiler supports the feature.